### PR TITLE
Make it possible to configure file / request size from api.properties

### DIFF
--- a/packages/api/api.properties.example
+++ b/packages/api/api.properties.example
@@ -51,4 +51,10 @@ spring.mail.password=
 # e.g. /srv/osahft/api/data
 data.dir=
 
+# Maximum file size [String]
+# Default: 10MB
+# spring.servlet.multipart.max-file-size=
 
+# Maximum request size [String]
+# Default: 10MB
+# spring.servlet.multipart.max-request-size=

--- a/packages/api/src/main/java/com/osahft/api/helper/ErrorHelper.java
+++ b/packages/api/src/main/java/com/osahft/api/helper/ErrorHelper.java
@@ -5,25 +5,33 @@ import lombok.Getter;
 import lombok.ToString;
 import org.springframework.http.HttpStatus;
 
+
 @ToString
 public class ErrorHelper {
 
-
     private static final ErrorResponse BAD_REQUEST = new ErrorResponse("-00001", "", HttpStatus.BAD_REQUEST);
-    private static final ErrorResponse TOO_MANY_REQUESTS = new ErrorResponse("-00002", "", HttpStatus.TOO_MANY_REQUESTS);
+    private static final ErrorResponse TOO_MANY_REQUESTS = new ErrorResponse("-00002", "",
+            HttpStatus.TOO_MANY_REQUESTS);
     @Getter
-    private static final ErrorResponse UNAUTHORIZED = new ErrorResponse("-10001", "The sender email is not authorized. Use POST /api/v1/transfers/mails/{mail_transfer_id}/auth/{authentication_code} first.", HttpStatus.UNAUTHORIZED);
+    private static final ErrorResponse UNAUTHORIZED = new ErrorResponse("-10001",
+            "The sender email is not authorized. Use POST /api/v1/transfers/mails/{mail_transfer_id}/auth/{authentication_code} first.",
+            HttpStatus.UNAUTHORIZED);
     private static final ErrorResponse FORBIDDEN = new ErrorResponse("-10002", "", HttpStatus.FORBIDDEN);
-    private static final ErrorResponse NOT_FOUND = new ErrorResponse("-20001", "MailTransfer not found: %s.", HttpStatus.NOT_FOUND);
-    private static final ErrorResponse SERVICE_UNAVAILABLE = new ErrorResponse("-30001", "", HttpStatus.SERVICE_UNAVAILABLE);
-
+    private static final ErrorResponse NOT_FOUND = new ErrorResponse("-20001", "MailTransfer not found: %s.",
+            HttpStatus.NOT_FOUND);
+    private static final ErrorResponse SERVICE_UNAVAILABLE = new ErrorResponse("-30001", "",
+            HttpStatus.SERVICE_UNAVAILABLE);
+    @Getter
+    private static final ErrorResponse INTERNAL_SERVER_ERROR = new ErrorResponse("-30002",
+            "An internal server error occurred.", HttpStatus.INTERNAL_SERVER_ERROR);
 
     public static ErrorResponse getBAD_REQUEST(String message) {
         return new ErrorResponse(BAD_REQUEST.getCode(), message, BAD_REQUEST.getHttpStatus());
     }
 
     public static ErrorResponse getNOT_FOUND(String mailTransferId) {
-        return new ErrorResponse(NOT_FOUND.getCode(), String.format(NOT_FOUND.getMessage(), mailTransferId), NOT_FOUND.getHttpStatus());
+        return new ErrorResponse(NOT_FOUND.getCode(), String.format(NOT_FOUND.getMessage(), mailTransferId),
+                NOT_FOUND.getHttpStatus());
     }
 
     public static ErrorResponse getSERVICE_UNAVAILABLE(String message) {

--- a/packages/api/src/main/resources/application.properties
+++ b/packages/api/src/main/resources/application.properties
@@ -5,3 +5,6 @@ springdoc.swagger-ui.path=
 # MAIL SETTINGS
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
+# MAX REQUEST / FILE SIZE
+spring.servlet.multipart.max-file-size=10MB
+spring.servlet.multipart.max-request-size=10MB


### PR DESCRIPTION
- add config options to api.properties.example
- add error handling for errors with file / request size
- refactor error handling to keep it uniform